### PR TITLE
Feature/fix intervention

### DIFF
--- a/app.R
+++ b/app.R
@@ -237,8 +237,8 @@ server <- function(input, output) {
   
   # Create Business as Usual and relative intervention (%) columns
   df[, c("bau", "intervention_mean_pct") := .(
-    ifelse(time >= INTERVENTION_DATE, no2 * intervention_abs, NA),
-    100 - (intervention_abs * 100)
+    ifelse(time >= INTERVENTION_DATE, no2 / intervention_abs, NA),
+    (intervention_abs * 100) - 100
   )]
   
   # Create CIs
@@ -249,7 +249,7 @@ server <- function(input, output) {
            detrended_abs - 2 * detrended_sd,
            intervention_abs - 2 * intervention_sd,
            bau * (intervention_abs - 2 * intervention_sd),
-           100 - (intervention_abs - 2 * intervention_sd) * 100
+           (intervention_abs - 2 * intervention_sd) * 100 - 100
          )]
   df[, c("detrended_upper",
          "intervention_upper",
@@ -258,7 +258,7 @@ server <- function(input, output) {
            detrended_abs + 2 * detrended_sd,
            intervention_abs + 2 * intervention_sd,
            bau * (intervention_abs + 2 * intervention_sd),
-           100 - (intervention_abs + 2 * intervention_sd) * 100
+           (intervention_abs + 2 * intervention_sd) * 100 - 100
          )]
   
   output$NEWC <- renderUI({

--- a/fit_models.R
+++ b/fit_models.R
@@ -1,6 +1,5 @@
 # Fits Univariate detrending models for 2 Newcastle AURN sites
 # Outputs a saved model object along with the latest states
-# TODO: Fit multivariate as well?
 library(tidyverse)
 library(lubridate)
 library(openair)
@@ -105,11 +104,15 @@ fit_univariate <- function(df, H=NA, Q=NA) {
 
   a1 <- c(rep(0, n_covars),
           coefs_yearly[1:(n_yearly*2), 1])
+  p1 <- matrix(0, nrow=n_covars_total, ncol=n_covars_total)
+  p1inf <- diag(n_covars_total)
   
   mod <- SSModel(log(df$no2) ~ 
                  SSMtrend(1, Q=Q) +                                   
                  SSMregression(form,
                                a1=a1,
+                               P1=p1,
+                               P1inf = p1inf,
                                data=df, Q=q_diag),
                   H=H)
   mod <- rename_states(mod, 
@@ -149,6 +152,7 @@ df_central |>
 df_to_update <- df_central[which(df_central$time >= START_DATE), ]
 results <- update_multiple_dates(df_to_update, 
                                  filt_central, 
+                                 SITES[['NEWC']]$intervention,
                                  list(list(date=START_DATE - days(1),
                                            a=NULL,
                                            P=NULL)))

--- a/fit_models.R
+++ b/fit_models.R
@@ -180,8 +180,8 @@ for (site in names(SITES)) {
   mod <- fit_univariate(df_daily |> filter(code == site, time < START_DATE ))
   filt <- KFS(mod, filtering = "state", smoothing = "none")
   final_states <- list(list(date=START_DATE - days(1),
-                              a=t(t(filt$a[filt$dims$n+1, ])),
-                              P=filt$P[, , filt$dims$n+1]))
+                              a=t(t(filt$att[filt$dims$n, ])),
+                              P=filt$Ptt[, , filt$dims$n]))
   
   detrended_ind <- which(colnames(filt$att) == 'level')
   

--- a/update_models.R
+++ b/update_models.R
@@ -37,7 +37,15 @@ for (site in names(SITES)) {
   detrended_ind <- which(row.names(a_last) == 'level')
   intervention_ind <- which(row.names(a_last) == 'Intervention')
   for (i in 1:nrow(this_df)) {
-    updated <- update_univariate(models[[site]], this_df[i, ], a_last, P_last)
+    # To kick-start the intervention variable, set a high covariance
+    # the day before. This will update the intervention state variable,
+    # as well as reducing the covariance massively in subsequent updates
+    if (this_df$time[i] == (SITES[[site]]$intervention - days(1))) {
+      P_last[intervention_ind, intervention_ind] <- 1e5
+    }
+    updated <- update_univariate(models[[site]], this_df[i, ],
+                                 SITES[[site]]$intervention,
+                                 a_last, P_last)
     a_last <- updated$a
     P_last <- updated$P
     this_states <- append(this_states, list(list(

--- a/utils.R
+++ b/utils.R
@@ -56,6 +56,7 @@ load_data <- function(site) {
 
 update_univariate <- function(model,
                               newdata,
+                              intervention_date,
                               alpha = NULL,
                               P = NULL) {
   if (is.null(P)) {
@@ -72,7 +73,7 @@ update_univariate <- function(model,
   Z[1, 2] <- log(newdata$ws)
   Z[1, 3] <- cos(2 * pi * newdata$wd / 360)
   Z[1, 4] <- sin(2 * pi * newdata$wd / 360)
-  Z[1, 5] <- ifelse(newdata$time >= as_date("2023-02-01"), 1, 0)
+  Z[1, 5] <- ifelse(newdata$time >= intervention_date, 1, 0)
   Z[1, 6] <- sin(2 * pi * (yday(newdata$time) / 365))
   Z[1, 7] <- cos(2 * pi * (yday(newdata$time) / 365))
   Z[1, 8] <- 1
@@ -92,11 +93,11 @@ update_univariate <- function(model,
        P = P_update)
 }
 
-update_multiple_dates <- function(data, model, states) {
+update_multiple_dates <- function(data, model, intervention_date, states) {
   a_new <- states[[length(states)]]$a
   P_new <- states[[length(states)]]$P
   for (i in 1:nrow(data)) {
-    updated <- update_univariate(model, data[i,], a_new, P_new)
+    updated <- update_univariate(model, data[i,], intervention_date, a_new, P_new)
     a_new <- updated$a
     P_new <- updated$P
     states <- append(states, list(list(


### PR DESCRIPTION
The intervention effect wasn't being updated, as its covariance was 0 leading up until the intervention date. This seems to be because the intervention was reached so much longer after the initial diffuse initialisation had started. To prompt this state to update, its covariance was set high (to 1e5) the day before the intervention date, allowing the state and its covariance to both update on the following day (the covariance quickly shrinks down to meaningful levels).

Furthermore,  on the web-app the conversion from the raw intervention state (log effect) to relative % effect was incorrect as well as the BAU calculation. These have been updated.