### PR TITLE
Feature/no log transform

### DIFF
--- a/app.R
+++ b/app.R
@@ -209,7 +209,7 @@ generate_tab <- function(df, site) {
       width = 6
     )
   first_sig <- this_df %>%
-    filter(intervention_upper < 1) %>%
+    filter(intervention_upper < 0) %>%
     slice_min(time, n = 1)
   if (nrow(first_sig) == 0)
     first_sig <- list(time = "Not yet")

--- a/app.R
+++ b/app.R
@@ -119,7 +119,7 @@ plot_detrended <- function(df) {
               name = "Measured",
               color = I("#1F77B4")) %>%
     add_lines(
-      y =  ~ detrended_abs,
+      y =  ~ detrended,
       name = "Detrended",
       legendgroup='Detrended',
       color = I("#FF7F0E")
@@ -163,14 +163,14 @@ plot_detrended <- function(df) {
 plot_intervention <- function(df) {
   plot_ly(df, x =  ~ time) %>%
     add_lines(
-      y =  ~ intervention_mean_pct,
+      y =  ~ intervention,
       name = "Intervention effect",
       color = I("#9467BD"),
       showlegend = FALSE
     ) %>%
     add_ribbons(
-      ymin = ~ intervention_lower_pct,
-      ymax = ~ intervention_upper_pct,
+      ymin = ~ intervention_lower,
+      ymax = ~ intervention_upper,
       name = "Intervention effect +/- 2sds",
       line = list(color = 'rgba(148, 103, 189, 0)'),
       fillcolor = 'rgba(148, 103, 189, 0.2)',
@@ -185,7 +185,7 @@ plot_intervention <- function(df) {
 }
 
 generate_tab <- function(df, site) {
-  this_df <- df[code == site & !is.na(detrended_abs)]
+  this_df <- df[code == site & !is.na(detrended)]
   p1 <- plot_detrended(this_df)
   p2 <- plot_intervention(this_df)
   
@@ -202,7 +202,7 @@ generate_tab <- function(df, site) {
   curr_effect <- this_df %>% slice_max(time, n = 1)
   obj2 <-
     valueBox(
-      sprintf("%.0f%%", curr_effect$intervention_mean_pct),
+      sprintf("%.1fppb", curr_effect$intervention),
       subtitle = sprintf("Intervention effect as of %s", curr_effect$time),
       icon = icon("bolt-lightning"),
       color = "green",
@@ -235,40 +235,39 @@ server <- function(input, output) {
   # for a general audience to not plot
   df[ is.na(no2), `:=` (detrended=NA, detrended_var=NA, intervention=NA, intervention_var=NA)]
   
-  # Convert log(mean) and log(var) into mean and sd
-  df[, c("detrended_abs", "intervention_abs") := .(exp(detrended + 0.5 * detrended_var),
-                                                   exp(intervention + 0.5 * intervention_var))]
-  df[, c("detrended_sd", "intervention_sd") := .(sqrt(detrended_abs ** 2 * (exp(detrended_var) - 1)),
-                                                 sqrt(intervention_abs ** 2 * (exp(intervention_var) - 1)))]
-  
-  # Create Business as Usual and relative intervention (%) columns
-  df[, c("bau", "detrended_abs", "intervention_mean_pct") := .(
-    ifelse(time >= intervention_date, no2 / intervention_abs, NA),
-    ifelse(time >= intervention_date, detrended_abs * intervention_abs, detrended_abs),
-    (intervention_abs * 100) - 100
+  # Create Business as Usual and update the Detrended column to include the intervention
+  # (otherwise it will remain pretty much static and be misleading)
+  # Also hide the intervention until the intervention date, i.e. so as to not plot any 
+  # variance that might have been used to start the filtering off
+  df[, c("bau", "detrended", "intervention", "intervention_var") := .(
+    ifelse(time >= intervention_date, no2 - intervention, NA),
+    ifelse(time >= intervention_date, detrended + intervention, detrended),
+    ifelse(time >= intervention_date, intervention, NA),
+    ifelse(time >= intervention_date, intervention_var, NA)
   )]
+  
+  # SSMs output variance, but SDs are used for CIs
+  df[, c("detrended_sd", "intervention_sd") := .(sqrt(detrended_var),
+                                                 sqrt(intervention_var))]
+  
 
   # Rescale detrending
-  df[, detrended_abs := detrended_abs - min(detrended_abs, na.rm = T)]
+  df[, detrended := detrended - min(detrended, na.rm = T)]
   
   # Create CIs
   df[, c("detrended_lower",
          "intervention_lower",
-         "bau_lower",
-         "intervention_lower_pct") := .(
-           detrended_abs - 2 * detrended_sd,
-           intervention_abs - 2 * intervention_sd,
-           bau * (intervention_abs - 2 * intervention_sd),
-           (intervention_abs - 2 * intervention_sd) * 100 - 100
+         "bau_lower") := .(
+           detrended - 2 * detrended_sd,
+           intervention - 2 * intervention_sd,
+           bau -  2 * intervention_sd  # TODO should this also take into account H?
          )]
   df[, c("detrended_upper",
          "intervention_upper",
-         "bau_upper",
-         "intervention_upper_pct") := .(
-           detrended_abs + 2 * detrended_sd,
-           intervention_abs + 2 * intervention_sd,
-           bau * (intervention_abs + 2 * intervention_sd),
-           (intervention_abs + 2 * intervention_sd) * 100 - 100
+         "bau_upper") := .(
+           detrended + 2 * detrended_sd,
+           intervention + 2 * intervention_sd,
+           bau + 2 * intervention_sd  # TODO should this also take into account H?
          )]
   
   output$NEWC <- renderUI({

--- a/utils.R
+++ b/utils.R
@@ -84,7 +84,7 @@ update_univariate <- function(model,
   
   H <- model$model$H[, , 1]
   # Most recent observation
-  y <- log(newdata$no2)
+  y <- newdata$no2
   
   # Get: P_t|t-1, alpha_t|t-1, Z_t, R_t
   # Calculate kalman gain as:


### PR DESCRIPTION
The current model uses a log transform on the outcome, this was initially done as it resulted in better fitting models at one point. However, it makes interpretation of the coefficients more complex, i.e. the intervention factor is on the scale of log(relative_change). The variance is also log(relative_change), so converting this to a standard deviation that can be used to generate CIs is confusing, as it's not clear what the order of square-root and exponentiating should be, and combining this with the intervention or raw data to generate Business-as-usual and detrended series is tricky.
Furthermore, using a log-transform was resulting in changes on the order of magnitude of 17%, which seems very optimistic. The unlogged transform gives an effect of ~2ppb, which seems more realistic.